### PR TITLE
Fix RewriteRule in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,5 @@
 <IfModule mod_rewrite.c>
     RewriteEngine on
 
-    RewriteRule ^.*$ /public/$1 [NC,L,QSA]
+    RewriteRule ^(.*)$ /public/$1 [NC,L,QSA]
 </IfModule>


### PR DESCRIPTION
.* requires parentheses for the backreference to work. 

Issue mentioned in https://github.com/MicrosoftDocs/azure-docs/issues/13496