### PR TITLE
Configure SSL of Azure MySQL in PHP (using PDO)

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -51,6 +51,11 @@ return [
             'prefix' => '',
             'strict' => true,
             'engine' => null,
+            'sslmode' => env('DB_SSLMODE', 'prefer'),
+            'options' => (env('MYSQL_SSL') && extension_loaded('pdo_mysql')) ? [
+                PDO::MYSQL_ATTR_SSL_KEY    => '/home/site/wwwroot/ssl/BaltimoreCyberTrustRoot.crt.pem',
+                PDO::MYSQL_ATTR_SSL_CA => '/home/site/wwwroot/ssl/BaltimoreCyberTrustRoot.crt.pem',
+            ] : []
         ],
 
         'pgsql' => [


### PR DESCRIPTION
Establish a secure connection to Azure Database for MySQL over SSL using PDO in PHP.