### PR TITLE
Change site root to use public/ in Laravel

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,5 @@
 <IfModule mod_rewrite.c>
     RewriteEngine on
-
+    RewriteCond %{REQUEST_URI} ^(.*)
     RewriteRule ^(.*)$ /public/$1 [NC,L,QSA]
 </IfModule>


### PR DESCRIPTION
Laravel uses the public/ subdirectory as the site root,  but the default PHP image for App Service uses Apache, and it doesn't let you customize the site root for your app. To work around this limitation, add an .htaccess file to the repository root (/home/site/wwwroot)