### PR TITLE
Handle Laravel Errors

### DIFF
--- a/default
+++ b/default
@@ -11,13 +11,6 @@ server {
         try_files $uri $uri/ /index.php?$args; # changed for Laravel
     }
 
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /html/;
-    }
-    
     # Disable .git directory
     location ~ /\.git {
         deny all;


### PR DESCRIPTION
Redirecting errors to a html file prevents laravel from displaying or handling errors